### PR TITLE
Security Fixes & Feedback Removal

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,10 +4,12 @@
   "version": "0.1.0",
   "description": "Developer-first accessibility inspector. Scan any page for WCAG violations and check colour contrast.",
   "permissions": ["activeTab","scripting","storage","windows","tabs","sidePanel"],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'none'; base-uri 'self';"
+  },
   "side_panel": {
     "default_path": "panel.html"
   },
-  "host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "background.js"
   },
@@ -26,12 +28,6 @@
     },
     "default_title": "Open AccessLens"
   },
-  "web_accessible_resources": [
-    {
-      "resources": ["panel.html","report.html","report.js"],
-      "matches": ["<all_urls>"]
-    }
-  ],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -99,6 +99,8 @@ function forwardToPanel(message) {
 
 // ── Message router ────────────────────────────────────────────────────────────
 chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+  // Reject any message that didn't originate from this extension's own pages or content scripts
+  if (sender.id !== chrome.runtime.id) return;
 
   if (message.type === "GET_TAB_ID") {
     if (trackedTabId !== null) {

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -824,6 +824,9 @@ startMutationObserver();
 // ── Message listener ──────────────────────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  // Reject any message that didn't come from this extension's background script
+  if (sender.id !== chrome.runtime.id) return;
+
   if (message.type === "RUN_SCAN") {
     runScan().then(sendResponse);
     return true;

--- a/src/panel/App.jsx
+++ b/src/panel/App.jsx
@@ -100,10 +100,6 @@ export default function App() {
     });
   }
 
-  function openFeedback() {
-    chrome.tabs.create({ url: "https://forms.gle/placeholder-feedback-form" });
-  }
-
   if (poppedOut && !isPopout) {
     return (
       <div className="popout-placeholder">
@@ -122,7 +118,7 @@ export default function App() {
     <div className="app">
       {showOnboarding && <OnboardingPanel onDone={completeOnboarding} />}
 
-      <Header tab={tab} setTab={setTab} scanBadge={scanBadge} onFeedback={openFeedback} isPopout={isPopout} sidePanelWindowId={sidePanelWindowId} />
+      <Header tab={tab} setTab={setTab} scanBadge={scanBadge} isPopout={isPopout} sidePanelWindowId={sidePanelWindowId} />
 
       <MainContent
         ready={ready}

--- a/src/panel/components/Header/Header.jsx
+++ b/src/panel/components/Header/Header.jsx
@@ -5,7 +5,7 @@ const TABS = [
   { id: "checklist", label: "Checklist" },
 ];
 
-export default function Header({ tab, setTab, scanBadge, onFeedback, isPopout, sidePanelWindowId }) {
+export default function Header({ tab, setTab, scanBadge, isPopout, sidePanelWindowId }) {
   function popOut() {
     chrome.runtime.sendMessage({ type: "POPOUT" });
   }
@@ -42,11 +42,7 @@ export default function Header({ tab, setTab, scanBadge, onFeedback, isPopout, s
               </svg>
             </button>
           )}
-          <button className="header-btn" onClick={onFeedback} aria-label="Send feedback">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
-            </svg>
-          </button>
+
         </div>
       </header>
 


### PR DESCRIPTION
- Removed Feedback Button (Avoids dealing with cookie policies and data collection for now, will put this back when we have more time to iron out the privacy stuff)


**Security Fixes (Before/After)**


**1. Web Accessible Resources**
File: public/manifest.json

**Before — HIGH RISK**

```
"web_accessible_resources": [
  {
    "resources": ["panel.html","report.html","report.js"],
    "matches": ["<all_urls>"]
  }
]
```
Any website on the internet could embed panel.html or report.html in an iframe, load report.js as a script, or probe extension state through UI timing attacks. The extension's internal pages were fully exposed to the open web.

**After — ELIMINATED**

Block removed entirely. No external website can reference, embed, or load any extension resource. Chrome APIs (windows.create, tabs.create) that open extension pages never required this entry — it only existed to grant external access, which was the problem.

**2. Content Security Policy**
File: public/manifest.json

Before — MEDIUM RISK
****No CSP defined. Extension pages had no protection against script injection, plugin execution, or base-tag hijacking if unsanitized content were ever rendered.

**After — MITIGATED**

```
"content_security_policy": {
  "extension_pages": "script-src 'self'; object-src 'none'; base-uri 'self';"
}
script-src 'self' — only scripts bundled with the extension can execute. No inline scripts, no external URLs.
object-src 'none' — <object> and <embed> plugin execution fully blocked.
base-uri 'self' — a <base> tag injected into an extension page cannot redirect relative URLs to an attacker's server.
```

**3. Message Listener Sender Validation**
`Files: src/background/index.js, src/content/index.js`

**Before — MEDIUM RISK**
```
// background/index.js
chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
  if (message.type === "GET_TAB_ID") { ... }
  if (message.type === "POPOUT") { ... }
  // ...
});

// content/index.js
chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
  if (message.type === "RUN_SCAN") { ... }
  // ...
});
```

Neither listener checked where the message came from. As a defense-in-depth gap: if XSS ever occurred in an extension page, it could send arbitrary messages to the background — triggering window creation, badge changes, or content script commands — without any gating. The content script similarly accepted instructions from any sender.

**After — MITIGATED**

```
// background/index.js
chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
  if (sender.id !== chrome.runtime.id) return;
  // ...
});

// content/index.js
chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
  if (sender.id !== chrome.runtime.id) return;
  // ...
});
```

sender.id is set by Chrome's runtime and cannot be spoofed. Any message not carrying the extension's own ID is silently dropped before a single line of handler logic runs. All legitimate senders — the panel, background script, and content scripts — share the same extension ID and pass through cleanly.

**What Remains (Accepted Risk)**

**Area | Risk | Reason not changed**

- `Auto-injected content script on all pages` | _LOW_ | Unavoidable for an accessibility scanner — can't inspect pages without DOM access
- `tabs permission` | _LOW_ | Required for tab-switch tracking and pop-out window logic
- `localStorage for checklist/focus log` | _LOW_ | Not sensitive data — a future migration to chrome.storage.local would be cleaner but carries no real exploit path

**Risk Level Summary**
**Item	| Before | After**

`Web accessible resources` | _HIGH_ | Eliminated
`Content Security Policy` | _MEDIUM_ | Mitigated
`Message sender validation` | _MEDIUM_ | Mitigated
`Auto-injected content script `| _LOW_ | Unchanged (accepted)
`tabs permission` | _LOW_ | Unchanged (accepted)
`localStorage usage` | _LOW_ | Unchanged (accepted)
